### PR TITLE
Fix dependency on system libraries for static configuration

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -187,16 +187,20 @@ class VTKConan(ConanFile):
         print('VTK libs ordered: ' + (';'.join(libs_ordered)))
         self.cpp_info.libs = libs_ordered
 
-        if not self.options.shared:
-            # Adding system libs without 'lib' prefix and '.so' or '.so.X' suffix.
-            if self.settings.os == 'Linux':
-                self.cpp_info.system_libs.append('pthread')
-                self.cpp_info.system_libs.append('dl')            # 'libvtksys-7.1.a' require 'dlclose', 'dlopen', 'dlsym' and 'dlerror' which on CentOS are in 'dl' library
-
+        # Adding system libs without 'lib' prefix and '.so' or '.so.X' suffix.
+        if self.settings.os == 'Linux':
+            self.cpp_info.system_libs.append('pthread')
+            self.cpp_info.system_libs.append('dl')            # 'libvtksys-7.1.a' require 'dlclose', 'dlopen', 'dlsym' and 'dlerror' which on CentOS are in 'dl' library
+            
+        if not self.options.shared and self.options.qt:
             if self.settings.os == 'Windows':
-                self.cpp_info.system_libs.append('Ws2_32.lib')    # 'vtksys-9.0d.lib' require 'gethostbyname', 'gethostname', 'WSAStartup' and 'WSACleanup' which are in 'Ws2_32.lib' library
-                self.cpp_info.system_libs.append('Psapi.lib')     # 'vtksys-9.0d.lib' require 'GetProcessMemoryInfo' which is in 'Psapi.lib' library
-                self.cpp_info.system_libs.append('dbghelp.lib')   # 'vtksys-9.0d.lib' require '__imp_SymGetLineFromAddr64', '__imp_SymInitialize' and '__imp_SymFromAddr' which are in 'dbghelp.lib' library
+                self.cpp_info.system_libs.append('Ws2_32')    # 'vtksys-9.0d.lib' require 'gethostbyname', 'gethostname', 'WSAStartup' and 'WSACleanup' which are in 'Ws2_32.lib' library
+                self.cpp_info.system_libs.append('Psapi')     # 'vtksys-9.0d.lib' require 'GetProcessMemoryInfo' which is in 'Psapi.lib' library
+                self.cpp_info.system_libs.append('dbghelp')   # 'vtksys-9.0d.lib' require '__imp_SymGetLineFromAddr64', '__imp_SymInitialize' and '__imp_SymFromAddr' which are in 'dbghelp.lib' library
+
+            if self.settings.os == 'Macos':
+                self.cpp_info.frameworks.extend(["CoreFoundation"]) # 'libvtkRenderingOpenGL2-9.0.a' require '_CFRelease', '_CFRetain', '_objc_msgSend' and much more which are in 'CoreFoundation' library
+                self.cpp_info.frameworks.extend(["Cocoa"])          # 'libvtkRenderingOpenGL2-9.0.a' require '_CGWarpMouseCursorPosition' and more, 'libvtkRenderingUI-9.0.a' require '_OBJC_CLASS_$_NSApplication' and more, which are in 'Cocoa' library
 
         self.cpp_info.includedirs = [
             "include/vtk-%s" % self.short_version,


### PR DESCRIPTION
1. Missing dependency on some system libraries (5 x `self.cpp_info.system_libs`)
2. `self.cpp_info.libs.append('pthread')` should be `self.cpp_info.system_libs.append('pthread')` because `pthread` is system library
3. GCC linker required libraries in appropriate order (clang and VS can figure out that by themselves including circular dependencies). Code at the beginning of `package_info()` only sorts them (no add nor remove any library). Code is taken from VTK 7.1, but works for me for VTK 9.0.1, so I believe it is correct for VTK 8.2.0 also.